### PR TITLE
Condense Code

### DIFF
--- a/assets/minecraft/sounds.json
+++ b/assets/minecraft/sounds.json
@@ -4,10 +4,10 @@
 		"replace": true,
 		"sounds":
 		[
-			{ "name": "music/menu/beginning_2", "stream": true },
-			{ "name": "music/menu/floating_trees", "stream": true },
-			{ "name": "music/menu/moog_city_2", "stream": true },
-			{ "name": "music/menu/mutation", "stream": true }
+			{ "name": "music/menu/beginning_2", 	"stream": true },
+			{ "name": "music/menu/floating_trees",	"stream": true },
+			{ "name": "music/menu/moog_city_2", 	"stream": true },
+			{ "name": "music/menu/mutation", 		"stream": true }
 		]
 	},
 	"music.game":
@@ -15,18 +15,18 @@
 		"replace": true,
 		"sounds":
 		[
-			{ "name": "music/game/clark", "stream": true },
-			{ "name": "music/game/danny", "stream": true },
-			{ "name": "music/game/dry_hands", "stream": true },
-			{ "name": "music/game/haggstrom", "stream": true },
-			{ "name": "music/game/key", "stream": true },
-			{ "name": "music/game/living_mice", "stream": true },
-			{ "name": "music/game/mice_on_venus", "stream": true },
-			{ "name": "music/game/minecraft", "stream": true },
-			{ "name": "music/game/wet_hands", "stream": true },
-			{ "name": "music/game/oxygene", "stream": true },
-			{ "name": "music/game/sweden", "stream": true },
-			{ "name": "music/game/wet_hands", "stream": true }
+			{ "name": "music/game/clark",			"stream": true },
+			{ "name": "music/game/danny", 			"stream": true },
+			{ "name": "music/game/dry_hands", 		"stream": true },
+			{ "name": "music/game/haggstrom", 		"stream": true },
+			{ "name": "music/game/key", 			"stream": true },
+			{ "name": "music/game/living_mice", 	"stream": true },
+			{ "name": "music/game/mice_on_venus", 	"stream": true },
+			{ "name": "music/game/minecraft", 		"stream": true },
+			{ "name": "music/game/wet_hands", 		"stream": true },
+			{ "name": "music/game/oxygene", 		"stream": true },
+			{ "name": "music/game/sweden", 			"stream": true },
+			{ "name": "music/game/wet_hands", 		"stream": true }
 		]
 	},
 	"music.creative":
@@ -34,12 +34,12 @@
 		"replace": true,
 		"sounds":
 		[
-			{ "name": "music/game/creative/aria_math", "stream": true },
-			{ "name": "music/game/creative/biome_fest", "stream": true },
-			{ "name": "music/game/creative/blind_spots", "stream": true },
-			{ "name": "music/game/creative/dreiton", "stream": true },
-			{ "name": "music/game/creative/haunt_muskie", "stream": true },
-			{ "name": "music/game/creative/taswell", "stream": true }
+			{ "name": "music/game/creative/aria_math", 		"stream": true },
+			{ "name": "music/game/creative/biome_fest", 	"stream": true },
+			{ "name": "music/game/creative/blind_spots", 	"stream": true },
+			{ "name": "music/game/creative/dreiton", 		"stream": true },
+			{ "name": "music/game/creative/haunt_muskie", 	"stream": true },
+			{ "name": "music/game/creative/taswell", 		"stream": true }
 		]
 	},
 	"music.overworld.badlands":


### PR DESCRIPTION
## Description
This pull request changes how biome sound events select their soundtrack and improves code readability through white space usage.

## Issue(s) Addressed
#3 Condense sounds data for biome sound events

## Changes
1. Biome sound events' sounds list now refer to the `music.game` sound event instead of having to have an entry for each C418 music; estimated 200 lines of code removed.
2. White space formatting was added to each element of the sounds list to make reading the JSON file easier.

## Testing
Currently no form of automatic testing is available, so manual testing through the game client will have to be used.

### Methodology
1. Load the resource pack in the game client.
2. Enable `Show Music Toast` under `Settings->Music & Sound`.
3. Set Music Frequency to `Constant` under `Settings->Music & Sound`.
4. Test the resource pack in various biomes and use `F3 + T` to reload the resource pack to quickly get the game client to select another sound track. The music toast will show the current track being played.