### PR TITLE
Nether Music Rebalance

### DIFF
--- a/assets/minecraft/sounds.json
+++ b/assets/minecraft/sounds.json
@@ -42,6 +42,52 @@
 			{ "name": "music/game/creative/taswell", 		"stream": true }
 		]
 	},
+	"music.nether.nether_wastes":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music/game/nether/crimson_forest/chrysopoeia",	"stream": true },
+			{ "name": "music/game/nether/nether_wastes/rubedo",			"stream": true },
+			{ "name": "music/game/nether/soulsand_valley/so_below",		"stream": true },
+			{ "name": "music/game/nether/ballad_of_the_cats",			"stream": true },
+			{ "name": "music/game/nether/concrete_halls",				"stream": true },
+			{ "name": "music/game/nether/dead_voxel",					"stream": true },
+			{ "name": "music/game/nether/warmth",						"stream": true }
+		]
+	},
+	"music.nether.basalt_deltas":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.nether.nether_wastes", "type": "event" }
+		]
+	},
+	"music.nether.crimson_forest":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.nether.nether_wastes", "type": "event" }
+		]
+	},
+	"music.nether.soul_sand_valley":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.nether.nether_wastes", "type": "event" }
+		]
+	},
+	"music.nether.warped_forest":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.nether.nether_wastes", "type": "event" }
+		]
+	},	
 	"music.overworld.badlands":
 	{
 		"replace": true,


### PR DESCRIPTION
## Description
This pull request includes sound events for every nether biome. Each biome also includes all 7 of the nether sound tracks to play. Before, most biomes had biome-exclusive music that are weighted heavily to play more frequently than the other music tracks that are listed in that biome.

## Nether Biome Sound Events
The following nether biome sound events were added:
1. `music.nether.nether_wastes`
2. `music.nether.crimson_forest`
3. `music.nether.basalt_deltas`
4. `music.nether.soul_sand_valley`
5. `music.nether.warped_forest`

## Design Decisions
* warped forest
  * the warped forest initially does not play any music tracks whatsoever due to a gameplay decision by Mojang. This resource pack changes the warped forest to now play music like the other biomes.
 * chrysopoeia, rubedo, so_below
   * these three music tracks, although not in the legacy edition, were kept since their tracks closely resemble the nether theme.

## Related to
#5