### PR TITLE
Pack Format Revisioning

### DIFF
--- a/LegacyTrack/pack.mcmeta
+++ b/LegacyTrack/pack.mcmeta
@@ -1,6 +1,7 @@
 {
     "pack": {
         "description": "Remaps music events to select C418 music.",
-        "pack_format": 64
+        "min_format": [69, 0],
+        "max_format": [69, 0]
     }
 }

--- a/LegacyTrackC/pack.mcmeta
+++ b/LegacyTrackC/pack.mcmeta
@@ -1,6 +1,7 @@
 {
     "pack": {
         "description": "Remaps music events to select C418 music.",
-        "pack_format": 64
+        "min_format": [69, 0],
+        "max_format": [69, 0]
     }
 }


### PR DESCRIPTION
## Description
This PR updates the pack.mcmeta files formatting data as the 1.21.9 Minecraft Java Update has introduced changes regarding how minecraft resource packs are versioned. See `Pack_Format` section in the [Minecraft Java 1.21.9 Update Article](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-9).

## pack.mcmeta
Both resource pack's pack.mcmeta file has replaced `pack_format` with `min_format` and `max_format` as required by the new 1.21.9 resource pack versioning requirements.

## Resource Pack Version
The version of both resource packs has been updated to `69.0`.

## Testing
Testing the resource pack with the new format details has been conducted to ensure compatibility with Minecraft 1.21.9 and incompatibility with Minecraft 1.21.8.

## Related To
#9 

## Additional Notes
Since this PR will introduce a change that will make this resource pack incompatible with Minecraft 1.21.8, the major version number will need to be incremented.