### PR TITLE
26.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 generatedPacks/
+*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.zip
+generatedPacks/

--- a/LegacyTrack/assets/minecraft/sounds.json
+++ b/LegacyTrack/assets/minecraft/sounds.json
@@ -128,6 +128,14 @@
 			{ "name": "music.game", "type": "event" }
 		]
 	},
+	"music.overworld.deep_dark"
+		{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.game", "type": "event" }
+		]
+	},
 	"music.overworld.flower_forest":
 	{
 		"replace": true,

--- a/LegacyTrack/assets/minecraft/sounds.json
+++ b/LegacyTrack/assets/minecraft/sounds.json
@@ -128,14 +128,6 @@
 			{ "name": "music.game", "type": "event" }
 		]
 	},
-	"music.overworld.deep_dark"
-		{
-		"replace": true,
-		"sounds":
-		[
-			{ "name": "music.game", "type": "event" }
-		]
-	},
 	"music.overworld.flower_forest":
 	{
 		"replace": true,

--- a/LegacyTrack/pack.mcmeta
+++ b/LegacyTrack/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Remaps music events to select C418 music.",
-        "min_format": [75, 0],
-        "max_format": [75, 0]
+        "min_format": [84, 0],
+        "max_format": [84, 0]
     }
 }

--- a/LegacyTrackC/assets/minecraft/sounds.json
+++ b/LegacyTrackC/assets/minecraft/sounds.json
@@ -128,6 +128,14 @@
 			{ "name": "music.creative", "type": "event" }
 		]
 	},
+	"music.overworld.deep_dark":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.creative", "type": "event" }
+		]
+	},
 	"music.overworld.flower_forest":
 	{
 		"replace": true,

--- a/LegacyTrackC/pack.mcmeta
+++ b/LegacyTrackC/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Remaps music events to select C418 music.",
-        "min_format": [75, 0],
-        "max_format": [75, 0]
+        "min_format": [84, 0],
+        "max_format": [84, 0]
     }
 }


### PR DESCRIPTION
## Description
This PR is for Minecraft Java edition 26.1.2 and also includes a fix to the deep dark biome not playing creative music when the player is in creative mode.

## Resource Pack Version
The resource pack version for this is 84.

## Deep Dark Fix
An issue that affected the deep dark biome involved its biome-specific music being played when the player was in creative mode. The intended feature is to have creative music play everywhere in the overworld. 

## Related To
#19 #21