### PR TITLE
Java 26.2

### DIFF
--- a/LegacyTrack/assets/minecraft/sounds.json
+++ b/LegacyTrack/assets/minecraft/sounds.json
@@ -87,7 +87,15 @@
 		[
 			{ "name": "music.nether.nether_wastes", "type": "event" }
 		]
-	},	
+	},
+	"music.overworld.sulfur_caves":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.game", "type": "event" }
+		]
+	},
 	"music.overworld.badlands":
 	{
 		"replace": true,

--- a/LegacyTrack/pack.mcmeta
+++ b/LegacyTrack/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Remaps music events to select C418 music.",
-        "min_format": [84, 0],
-        "max_format": [84, 0]
+        "min_format": [88, 0],
+        "max_format": [88, 0]
     }
 }

--- a/LegacyTrackC/assets/minecraft/sounds.json
+++ b/LegacyTrackC/assets/minecraft/sounds.json
@@ -87,7 +87,15 @@
 		[
 			{ "name": "music.nether.nether_wastes", "type": "event" }
 		]
-	},	
+	},
+	"music.overworld.sulfur_caves":
+	{
+		"replace": true,
+		"sounds":
+		[
+			{ "name": "music.creative", "type": "event" }
+		]
+	},
 	"music.overworld.badlands":
 	{
 		"replace": true,

--- a/LegacyTrackC/pack.mcmeta
+++ b/LegacyTrackC/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Remaps music events to select C418 music.",
-        "min_format": [84, 0],
-        "max_format": [84, 0]
+        "min_format": [88, 0],
+        "max_format": [88, 0]
     }
 }


### PR DESCRIPTION
## Description
This PR is for Minecraft Java edition 26.2.

## Resource Pack Version
The resource pack version has been updated to 88.0. See: [Java 26.2 Release Notes](https://www.minecraft.net/en-us/article/minecraft-java-edition-26-2#:~:text=Technical)

## New Sound Event
`music.overworld.sulfur_caves` has been added for both survival and creative. See: [Java 26.2 Release Notes](https://www.minecraft.net/en-us/article/minecraft-java-edition-26-2#:~:text=music.overworld.sulfur_caves)

## Reference
#23 

## Resources
[Java 26.2 Release Notes](https://www.minecraft.net/en-us/article/minecraft-java-edition-26-2)
